### PR TITLE
ft: Add the ability to modify different fields or all request fields at once (develop)

### DIFF
--- a/api/models/req_helper.py
+++ b/api/models/req_helper.py
@@ -80,8 +80,11 @@ class RequestHelper(object):
             req_desc: Request description.
 
         Returns:
-            The created RequestClass object in dictionary form i.e.
-            vars(some_obj)
+            The created RequestClass object in dictionary form
+            For example:
+
+            {'req_id': 1, req_name': 'somename',
+            'req_type': 'sometype', 'req_desc': 'somedescription'}
         """
 
         if self.check_request(req_id, req_name, req_type, req_desc):
@@ -89,8 +92,57 @@ class RequestHelper(object):
             self.req_db.append(new_req)
             return vars(new_req)
 
-    def change_request(self, req_id,
-                       new_name=None, new_type=None, new_desc=None):
+    def change_req_name(self, req_id, new_name):
+        """Changes a request's name.
+
+        Takes a request's id and new name and updates
+        the RequestClass object with the request id specified.
+
+        Args:
+            req_id: Request id number
+            req_name: Request name.
+
+        Returns:
+            The updated RequestClass object in dictionary form
+            For example:
+
+            {'req_id': 1, req_name': 'newname',
+            'req_type': 'sometype', 'req_desc': 'somedescription'}
+        """
+
+        valid_req_name = re.search(r'^[A-Za-z\s]', new_name)
+        for req in self.req_db:
+            if req_id == req.req_id and valid_req_name:
+                req.req_name = new_name
+                return vars(req)
+            return 'Request doesn\'t exist or you have wrong values.'
+
+    def change_req_type(self, req_id, new_type):
+        """Changes a request.
+
+        Takes a request's id and new type and updates
+        the RequestClass object with the request id specified.
+
+        Args:
+            req_id: Request id number
+            req_type: Request type.
+
+        Returns:
+            The updated RequestClass object in dictionary form
+            For example:
+
+            {'req_id': 1, req_name': 'somename',
+            'req_type': 'newtype', 'req_desc': 'somedescription'}
+        """
+
+        valid_req_type = re.search(r'^[A-Za-z\s]', new_type)
+        for req in self.req_db:
+            if req_id == req.req_id and valid_req_type:
+                req.req_type = new_type
+                return vars(req)
+            return 'Request doesn\'t exist or you have wrong values.'
+
+    def change_req_desc(self, req_id, new_desc):
         """Changes a request.
 
         Takes a request's id, the new name, type and description
@@ -98,32 +150,22 @@ class RequestHelper(object):
 
         Args:
             req_id: Request id number
-            req_name: Request name.
-            req_type: Request type.
             req_desc: Request description.
 
         Returns:
-            The updated RequestClass object in dictionary form i.e.
-            vars(some_obj)
+            The updated RequestClass object in dictionary form
+            For example:
+
+            {'req_id': 1, req_name': 'somename',
+            'req_type': 'sometype', 'req_desc': 'newdescription'}
         """
 
-        if self.check_request(req_id, new_name, new_type, new_desc):
-            for req in self.req_db:
-                if req_id == req.req_id:
-                    old_req_name = req.req_name
-                    old_req_type = req.req_type
-                    old_req_desc = req.req_desc
-
-                    if new_name and new_name != old_req_name:
-                        req.req_name = new_name
-
-                    if new_type and new_type != old_req_type:
-                        req.req_type = new_type
-
-                    if new_desc and new_desc != old_req_desc:
-                        req.req_desc = new_desc
-                    return vars(req)
-        return False
+        valid_req_desc = re.search(r'^[A-Za-z\s]', new_desc)
+        for req in self.req_db:
+            if req_id == req.req_id and valid_req_desc:
+                req.req_desc = new_desc
+                return vars(req)
+            return 'Request doesn\'t exist or you have wrong values.'
 
     def fetch_by_id_request(self, req_id):
         """Returns a request with matching id.

--- a/api/views/request_view.py
+++ b/api/views/request_view.py
@@ -38,12 +38,27 @@ def fetch_request_id(requestId):
 @req.route('/users/requests/<int:requestId>', methods=['PUT'])
 def modify_request(requestId):
     json_data = request.get_json()
-    request_name = json_data['req_name']
-    request_type = json_data['req_type']
-    request_desc = json_data['req_desc']
-    request_id = requestId
-    mod_req = request_helper.change_request(
-              request_id, request_name, request_type, request_desc)
-    if mod_req:
-        return jsonify({'Request updated': mod_req}), 201
+
+    for key in json_data.keys():
+        if key == 'req_name' and json_data['req_name']:
+            new_req_name = json_data['req_name']
+            mod_req = request_helper.change_req_name(
+                requestId, new_req_name
+            )
+            if mod_req:
+                return jsonify({'Request updated': mod_req}), 201
+        elif key == 'req_type' and json_data['req_type']:
+            new_req_type = json_data['req_type']
+            mod_req = request_helper.change_req_name(
+                requestId, new_req_type
+            )
+            if mod_req:
+                return jsonify({'Request updated': mod_req}), 201
+        elif key == 'req_desc' and json_data['req_desc']:
+            new_req_desc = json_data['req_desc']
+            mod_req = request_helper.change_req_desc(
+                requestId, new_req_desc
+            )
+            if mod_req:
+                return jsonify({'Request updated': mod_req}), 201
     return jsonify(message='Invalid request id or values.'), 400

--- a/tests/test_modify_request.py
+++ b/tests/test_modify_request.py
@@ -16,7 +16,7 @@ class MaintenanceViews(unittest.TestCase):
     def tearDown(self):
         self.req_db
 
-    def test_modify_req_success(self):
+    def test_modify_req_name_success(self):
         new_req = self.test_request.post(
             '/api/v1/users/requests',
             content_type='application/json',
@@ -31,9 +31,7 @@ class MaintenanceViews(unittest.TestCase):
             content_type='application/json',
             data=json.dumps(
                 dict(
-                    req_name='New Test Record',
-                    req_type='New Test',
-                    req_desc='A new failing test'
+                    req_name='New Test Record'
                 )
             ))
         self.assertEqual(response.status_code, 201)
@@ -52,14 +50,30 @@ class MaintenanceViews(unittest.TestCase):
             '/api/v1/users/requests/' + str(req_id),
             content_type='application/json',
             data=json.dumps(
-                dict(
-                    req_name='',
-                    req_type='New Test',
-                    req_desc='A new failing test'
-                )
+                dict(req_name='')
             ))
         self.assertEqual(response.status_code,
                          400, msg='Empty req name allowed')
+
+    def test_modify_req_type_success(self):
+        new_req = self.test_request.post(
+            '/api/v1/users/requests',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    req_name='Failing Test',
+                    req_type='Test',
+                    req_desc='A failing test')))
+        req_id = json.loads(new_req.get_data())['new_request']['req_id']
+        response = self.test_request.put(
+            '/api/v1/users/requests/' + str(req_id),
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    req_type='Testing'
+                )
+            ))
+        self.assertEqual(response.status_code, 201)
 
     def test_modify_req_without_type(self):
         new_req = self.test_request.post(
@@ -75,14 +89,30 @@ class MaintenanceViews(unittest.TestCase):
             '/api/v1/users/requests/' + str(req_id),
             content_type='application/json',
             data=json.dumps(
-                dict(
-                    req_name='Failing Test',
-                    req_type='',
-                    req_desc='A new failing test'
-                )
+                dict(req_type='')
             ))
         self.assertEqual(response.status_code,
                          400, msg='Empty req type allowed')
+
+        def test_modify_req_desc_success(self):
+            new_req = self.test_request.post(
+            '/api/v1/users/requests',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    req_name='Failing Test',
+                    req_type='Test',
+                    req_desc='A failing test')))
+        req_id = json.loads(new_req.get_data())['new_request']['req_id']
+        response = self.test_request.put(
+            '/api/v1/users/requests/' + str(req_id),
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    req_desc='Something new.'
+                )
+            ))
+        self.assertEqual(response.status_code, 201)
 
     def test_modify_req_without_desc(self):
         new_req = self.test_request.post(
@@ -98,11 +128,29 @@ class MaintenanceViews(unittest.TestCase):
             '/api/v1/users/requests/' + str(req_id),
             content_type='application/json',
             data=json.dumps(
-                dict(
-                    req_name='New Failing Test',
-                    req_type='Test',
-                    req_desc=''
-                )
+                dict(req_desc='')
             ))
         self.assertEqual(response.status_code,
                          400, msg='Empty req description allowed')
+
+    def test_modify_all_req_success(self):
+        new_req = self.test_request.post(
+            '/api/v1/users/requests',
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    req_name='Failing Test',
+                    req_type='Test',
+                    req_desc='A failing test')))
+        req_id = json.loads(new_req.get_data())['new_request']['req_id']
+        response = self.test_request.put(
+            '/api/v1/users/requests/' + str(req_id),
+            content_type='application/json',
+            data=json.dumps(
+                dict(
+                    req_name='New Test Record',
+                    req_type='New test',
+                    req_desc='Something new'
+                )
+            ))
+        self.assertEqual(response.status_code, 201)

--- a/tests/test_req_helper.py
+++ b/tests/test_req_helper.py
@@ -10,10 +10,10 @@ class TestRequest(unittest.TestCase):
 
     def setUp(self):
         self.request_helper = RequestHelper()
-        self.req_db = []
+        self.req_db = self.request_helper.req_db = []
 
     def tearDown(self):
-        self.req_db
+        self.req_db = self.request_helper.req_db = []
 
     def test_req_db_type(self):
         self.assertIsInstance(self.request_helper.req_db, list,
@@ -26,7 +26,8 @@ class TestRequest(unittest.TestCase):
                               msg='Request helper class not instantiated')
 
     def test_req_helper_attributes(self):
-        args = ['req_db', 'check_request', 'change_request',
+        args = ['req_db', 'check_request', 'change_req_name',
+                'change_req_type', 'change_req_desc',
                 'fetch_by_id_request', 'fetch_all_requests']
         for arg in args:
             self.assertTrue(hasattr(self.request_helper, arg),
@@ -73,6 +74,8 @@ class TestRequest(unittest.TestCase):
     def test_create_request_return_object_success(self):
         new_req = self.request_helper.create_request(
             1, 'somename', 'sometype', 'somedescription')
+        self.assertNotEqual(len(self.req_db), 0,
+                            msg='No request created')
         for req in self.req_db:
             self.assertIs(vars(req), new_req, msg='No request created.')
             self.assertTrue(hasattr(req, '__dict__'),
@@ -80,48 +83,143 @@ class TestRequest(unittest.TestCase):
             self.assertIsInstance(req, RequestClass,
                                   msg='Invalid RequestClass object')
 
-    def test_change_req_method_has_correct_args(self):
-        args = ['self', 'req_id', 'new_name', 'new_type', 'new_desc']
+    def test_change_req_name_has_correct_args(self):
+        args = ['self', 'req_id', 'new_name']
         for arg in args:
             self.assertIn(arg, str(inspect.getfullargspec(
-                self.request_helper.change_request)),
+                self.request_helper.change_req_name)),
                 msg='Method has no {0} parameter'.format(arg))
 
-    def test_change_req_method_success(self):
+    def test_change_req_name_success(self):
         self.request_helper.create_request(
             1, 'somename', 'sometype', 'somedescription')
+        self.assertNotEqual(len(self.req_db), 0,
+                            msg='No request created.')
         for req in self.req_db:
             old_req_id = req.req_id
             old_req_name = req.req_name
+            self.assertIn(req, self.req_db,
+                          msg='Request not in database.')
+            self.assertIsInstance(req, RequestClass,
+                                  msg='Invalid RequestClass object.')
+            mod_req = self.request_helper.change_req_name(1, 'newname')
+            self.assertNotEqual(old_req_name, req.req_name,
+                                msg='Request name not updated.')
+            self.assertEqual(old_req_id, req.req_id,
+                             msg='Request ID has been changed.')
+            self.assertIsInstance(mod_req, dict,
+                                  msg='Request not returned as a dictionary.')
+
+    def test_change_req_name_fail_invalid_id(self):
+        self.request_helper.create_request(
+            1, 'somename', 'sometype', 'somedescription'
+        )
+        invalid_req = self.request_helper.change_req_name(
+            2, 'newname')
+        self.assertEqual(invalid_req,
+                         'Request doesn\'t exist or you have wrong values.',
+                         msg='Non-existent request name can be changed.')
+
+    def test_change_req_name_empty_field_fail(self):
+        self.request_helper.create_request(
+            1, 'somename', 'sometype', 'somedescription'
+        )
+        invalid_req = self.request_helper.change_req_name(1, '')
+        self.assertEqual(invalid_req,
+                         'Request doesn\'t exist or you have wrong values.',
+                         msg='Empty values allowed as valid fields.')
+
+    def test_change_req_type_has_correct_args(self):
+        args = ['self', 'req_id', 'new_type']
+        for arg in args:
+            self.assertIn(arg, str(inspect.getfullargspec(
+                self.request_helper.change_req_type)),
+                msg='Method has no {0} parameter'.format(arg))
+
+    def test_change_req_type_success(self):
+        self.request_helper.create_request(
+            1, 'somename', 'sometype', 'somedescription')
+        self.assertNotEqual(len(self.req_db), 0,
+                            msg='No request created.')
+        for req in self.req_db:
+            old_req_id = req.req_id
             old_req_type = req.req_type
+            self.assertIn(req, self.req_db,
+                          msg='Request not in database.')
+            self.assertIsInstance(req, RequestClass,
+                                  msg='Invalid RequestClass object.')
+            mod_req = self.request_helper.change_req_type(1, 'newname')
+            self.assertNotEqual(old_req_type, req.req_type,
+                                msg='Request type not updated.')
+            self.assertEqual(old_req_id, req.req_id,
+                             msg='Request ID has been changed.')
+            self.assertIsInstance(mod_req, dict,
+                                  msg='Request not returned as a dictionary.')
+
+    def test_change_req_type_fail_invalid_id(self):
+        self.request_helper.create_request(
+            1, 'somename', 'sometype', 'somedescription'
+        )
+        invalid_req = self.request_helper.change_req_type(
+            2, 'newname')
+        self.assertEqual(invalid_req,
+                         'Request doesn\'t exist or you have wrong values.',
+                         msg='Non-existent request type can be changed.')
+
+    def test_change_req_type_empty_field_fail(self):
+        self.request_helper.create_request(
+            1, 'somename', 'sometype', 'somedescription'
+        )
+        invalid_req = self.request_helper.change_req_type(1, '')
+        self.assertEqual(invalid_req,
+                         'Request doesn\'t exist or you have wrong values.',
+                         msg='Empty values allowed as valid fields.')
+
+    def test_change_req_desc_has_correct_args(self):
+        args = ['self', 'req_id', 'new_desc']
+        for arg in args:
+            self.assertIn(arg, str(inspect.getfullargspec(
+                self.request_helper.change_req_desc)),
+                msg='Method has no {0} parameter'.format(arg))
+
+    def test_change_req_desc_success(self):
+        self.request_helper.create_request(
+            1, 'somename', 'sometype', 'somedescription')
+        self.assertNotEqual(len(self.req_db), 0,
+                            msg='No request created.')
+        for req in self.req_db:
+            old_req_id = req.req_id
             old_req_desc = req.req_desc
             self.assertIn(req, self.req_db,
                           msg='Request not in database.')
             self.assertIsInstance(req, RequestClass,
                                   msg='Invalid RequestClass object.')
-            mod_req = self.request_helper.change_request(
-                        1, 'newname', 'newtype', 'newdescription')
-            self.assertNotEqual(old_req_name, req.req_name,
-                                msg='Request name not updated.')
-            self.assertNotEqual(old_req_type, req.req_type,
-                                msg='Request type not updated.')
+            mod_req = self.request_helper.change_req_desc(1, 'newdescription')
             self.assertNotEqual(old_req_desc, req.req_desc,
                                 msg='Request description not updated.')
             self.assertEqual(old_req_id, req.req_id,
                              msg='Request ID has been changed.')
-            self.assertIs(mod_req, req, msg='Request not changed')
             self.assertIsInstance(mod_req, dict,
                                   msg='Request not returned as a dictionary.')
 
-    def test_change_req_method_fail_invalid_id(self):
+    def test_change_req_desc_fail_invalid_id(self):
         self.request_helper.create_request(
             1, 'somename', 'sometype', 'somedescription'
         )
-        invalid_req = self.request_helper.change_request(
-            2, 'newname', 'newtype', 'newdescription'
+        invalid_req = self.request_helper.change_req_type(
+            2, 'newdescription')
+        self.assertEqual(invalid_req,
+                         'Request doesn\'t exist or you have wrong values.',
+                         msg='Non-existent req description can be changed.')
+
+    def test_change_req_desc_empty_field_fail(self):
+        self.request_helper.create_request(
+            1, 'somename', 'sometype', 'somedescription'
         )
-        self.assertFalse(invalid_req,
-                         msg='Non-existent request can be changed.')
+        invalid_req = self.request_helper.change_req_desc(1, '')
+        self.assertEqual(invalid_req,
+                         'Request doesn\'t exist or you have wrong values.',
+                         msg='Empty values allowed as valid fields.')
 
     def test_fetch_req_id_method_has_correct_args(self):
         args = ['self', 'req_id']


### PR DESCRIPTION
#### What's this PR do?
This PR adds the ability to modify different fields individually or all request fields at once as well as adding some modifications to the existing doc strings of the methods in the `req_helper` module,
merging the changes into `develop` branch.

#### Where should the reviewer start?
The commit history of this pull request.

#### How should this be manually tested?
See the [README](https://github.com/leni1/main-tracker-api/blob/master/README.md) for details on how to run tests.
