### PR TITLE
ch: Escape the brackets in create_app call

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn -w 4 api:app
+web: gunicorn -w 4 "api:create_app()"


### PR DESCRIPTION
#### What's this PR do?
This pull request merges changes to the `Procfile` so that the brackets in the `create_app` call by `gunicorn` are escaped using quotes.

#### Where should the reviewer start?
The commit history of this pull request.

#### How should this be manually tested?
Installing the requirements in `requirements.txt` within an activated virtual environment as per the `README` and running the command `gunicorn "api:create_app"` in the terminal.

#### Any background context you want to provide?
The changes were made as part of troubleshooting why the API endpoints weren't able to accessed via the expected endpoints on Heroku. 